### PR TITLE
Change RTT unit to milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Usage
 
 Start the `tcp_metrics` application and call `tcp_metrics:lookup(Ip)`
 or read straight from the ETS table created; the returned value is
-either `undefined` or an integer in microseconds.
+either `undefined` or an integer in milliseconds.

--- a/c_src/tcp_metrics_port.c
+++ b/c_src/tcp_metrics_port.c
@@ -80,11 +80,9 @@ static int handle_packet(struct nl_msg *msg, void *arg)
      * that explains why. */
     unsigned long rtt = 0;
     struct nlattr *m;
-    if ((m = metrics[1+TCP_METRIC_RTT_US])) {
+    if ((m = metrics[1+TCP_METRIC_RTT]))
         rtt = nla_get_u32(m);
-    } else if ((m = metrics[1+TCP_METRIC_RTT])) {
-        rtt = nla_get_u32(m) * 1000;
-    } else
+    else
         return NL_SKIP;
 
     update(addr, rtt>>3);

--- a/src/tcp_metrics.erl
+++ b/src/tcp_metrics.erl
@@ -22,7 +22,7 @@ init(Parent) ->
     loop(create_port(), <<>>).
 
 
-%% lookup the estimated RTT in usecs for an IP.
+%% lookup the estimated RTT in millisecs for an IP.
 -spec lookup(ip() |
              {0..255,0..255,0..255,0..255} |
              binary())


### PR DESCRIPTION
Microsecond precision was added after 3.13, which is what Travis CI
provides.  So we scale back our interface.
