### PR TITLE
Don't build except on Linux

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,6 @@
 {erl_opts, [debug_info]}.
 
 {pre_hooks,
-  [{"(linux|darwin|solaris)", compile, "make -C c_src"},
-   {"(freebsd)", compile, "gmake -C c_src"}]}.
+  [{"(linux)", compile, "make -C c_src"}]}.
 {post_hooks,
-  [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
-   {"(freebsd)", clean, "gmake -C c_src clean"}]}.
+  [{"(linux)", clean, "make -C c_src clean"}]}.


### PR DESCRIPTION
Hopefully this is the least change necessary to permit building
dependent projects on BSDs.
