### PR TITLE
Catch badarg if ets table isn't around yet

### DIFF
--- a/src/tcp_metrics.erl
+++ b/src/tcp_metrics.erl
@@ -40,7 +40,10 @@ init(Parent) ->
              binary())
             -> rtt() | undefined.
 lookup(Ip) when is_integer(Ip) ->
-    case ets:lookup(?TABLE, Ip) of
+    case try ets:lookup(?TABLE, Ip)
+         catch error:badarg -> []
+         end
+    of
         [{_Ip, Rtt}] -> Rtt;
         [] -> undefined
     end;


### PR DESCRIPTION
Some microbenchmarking reveals that this is cheaper, on the fast path,
than calling `ets:info/2` to check if the table exists.
